### PR TITLE
Prevent ipv6 socket from being used

### DIFF
--- a/jni/vnc/LibVNCServer-0.9.9/libvncserver/sockets.c
+++ b/jni/vnc/LibVNCServer-0.9.9/libvncserver/sockets.c
@@ -407,8 +407,10 @@ rfbProcessNewConnection(rfbScreenInfoPtr rfbScreen)
     }
     if (FD_ISSET(rfbScreen->listenSock, &listen_fds)) 
       chosen_listen_sock = rfbScreen->listenSock;
+    /*
     if (FD_ISSET(rfbScreen->listen6Sock, &listen_fds)) 
       chosen_listen_sock = rfbScreen->listen6Sock;
+    */
 
     if ((sock = accept(chosen_listen_sock,
 		       (struct sockaddr *)&addr, &addrlen)) < 0) {

--- a/vnc-build.sh
+++ b/vnc-build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -x
 
 # $ vnc-build -a [18|19]
 


### PR DESCRIPTION
Resolve:
`06/10/2016 10:51:24 rfbCheckFds: accept: Bad file number`
when trying to connect with Irene
